### PR TITLE
[add] Event subscription batching

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # Diode
 
-A simple state propagation tool for React. It takes advantage of
+A simple, eventually consistent, state propagation tool for React. It
+takes advantage of
 [components that are pure](http://facebook.github.io/react/docs/pure-render-mixin.html)
 to significantly simplify event subscription when propagating changes
 in the data layer.
@@ -10,6 +11,24 @@ Diode has no dependencies.
 **Diode is an event emitter with one event**. By including the `Stateful`
 mixin, an expected `getState` method is called every time the Diode
 publishes a change.
+
+**Diode batches event subscriptions using `requestAnimationFrame`**. In
+short, this means that sequential publications will be clumped:
+
+```javascript
+Diode.subscribe(callback)
+
+for (var i = 1000; i > 0; i--) {
+  Diode.publish()
+}
+
+// callback will only fire once
+```
+
+This means that state changes which would activate `Diode.publish`
+multiple times, such as an action which affects multiple data stores,
+will trigger once. This should improve efficiency and simplify actions
+such as merging records.
 
 It is also quite small (see [API](#api)). We found ourselves building
 something similar to it on several projects and decided it was better

--- a/README.md
+++ b/README.md
@@ -1,4 +1,10 @@
-# Diode
+---
+
+[![NPM](https://nodei.co/npm/diode.png)](https://npmjs.org/package/diode)
+[![Build Status](https://travis-ci.org/vigetlabs/diode.png?branch=master)](https://travis-ci.org/vigetlabs/diode)
+[![Coverage Status](https://coveralls.io/repos/vigetlabs/diode/badge.svg)](https://coveralls.io/r/vigetlabs/diode)
+
+---
 
 A simple, eventually consistent, state propagation tool for React. It
 takes advantage of
@@ -33,13 +39,6 @@ such as merging records.
 It is also quite small (see [API](#api)). We found ourselves building
 something similar to it on several projects and decided it was better
 to keep it in one place.
-
----
-
-[![Build Status](https://travis-ci.org/vigetlabs/diode.png?branch=master)](https://travis-ci.org/vigetlabs/diode)
-[![Coverage Status](https://coveralls.io/repos/vigetlabs/diode/badge.svg)](https://coveralls.io/r/vigetlabs/diode)
-
----
 
 ## Usage
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,7 @@
-[![NPM](https://nodei.co/npm/diode.png)](https://npmjs.org/package/diode)
+[![NPM](https://nodei.co/npm/diode.png?compact=true)](https://npmjs.org/package/diode)
+
+---
+
 [![Build Status](https://travis-ci.org/vigetlabs/diode.png?branch=master)](https://travis-ci.org/vigetlabs/diode)
 [![Coverage Status](https://coveralls.io/repos/vigetlabs/diode/badge.svg)](https://coveralls.io/r/vigetlabs/diode)
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,3 @@
----
-
 [![NPM](https://nodei.co/npm/diode.png)](https://npmjs.org/package/diode)
 [![Build Status](https://travis-ci.org/vigetlabs/diode.png?branch=master)](https://travis-ci.org/vigetlabs/diode)
 [![Coverage Status](https://coveralls.io/repos/vigetlabs/diode/badge.svg)](https://coveralls.io/r/vigetlabs/diode)

--- a/diode.js
+++ b/diode.js
@@ -6,6 +6,17 @@
 
 var invariant  = require('./invariant')
 var _callbacks = []
+var _tick      = null;
+
+/**
+ * Callbacks are eventually executed, Diode does not promise
+ * immediate consistency so that state propagation can be batched
+ */
+var _flush = function() {
+  for (var i = 0, length = _callbacks.length; i < length; i++) {
+    _callbacks[i]()
+  }
+}
 
 var Diode = {
 
@@ -35,9 +46,8 @@ var Diode = {
    * Trigger every callback in the Set
    */
   publish: function() {
-    _callbacks.forEach(function(callback) {
-      callback()
-    })
+    cancelAnimationFrame(_tick)
+    _tick = requestAnimationFrame(_flush)
   }
 
 }

--- a/diode.js
+++ b/diode.js
@@ -46,8 +46,10 @@ var Diode = {
    * Trigger every callback in the Set
    */
   publish: function() {
-    cancelAnimationFrame(_tick)
-    _tick = requestAnimationFrame(_flush)
+    if (_callbacks.length) {
+      cancelAnimationFrame(_tick)
+      _tick = requestAnimationFrame(_flush)
+    }
   }
 
 }

--- a/diode.js
+++ b/diode.js
@@ -46,7 +46,7 @@ var Diode = {
    * Trigger every callback in the Set
    */
   publish: function() {
-    if (_callbacks.length) {
+    if (_callbacks.length > 0) {
       cancelAnimationFrame(_tick)
       _tick = requestAnimationFrame(_flush)
     }

--- a/invariant.js
+++ b/invariant.js
@@ -1,8 +1,10 @@
+var production = (typeof process === 'undefined') ? false : process.env.NODE_ENV === 'production'
+
 module.exports = function(condition, message) {
-  if ("production" !== process.env.NODE_ENV && !condition) {
+  if (!production && !condition) {
     var error = new Error(message);
 
-    error.framesToPop = 1; // we don't care about invariant's own frame
+    error.framesToPop = 1 // we don't care about invariant's own frame
 
     throw error;
   }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "diode",
-  "version": "1.1.0",
-  "description": "A simple state propagation tool for Flux/React apps",
+  "version": "2.0.0",
+  "description": "A simple, eventually consistent, state propagation tool for Flux/React apps",
   "main": "diode.js",
   "scripts": {
     "test": "karma start",

--- a/tests/diode-test.js
+++ b/tests/diode-test.js
@@ -1,23 +1,37 @@
 describe('Diode', function() {
   var Diode = require('diode')
 
-  it ('can subscribe callbacks', function() {
+  it ('can subscribe callbacks', function(done) {
+    Diode.subscribe(done);
+    Diode.publish();
+  })
+
+  it ('batches subscriptions', function(done) {
     let stub = sinon.stub()
 
     Diode.subscribe(stub);
-    Diode.publish();
 
-    stub.should.have.been.called
+    for (var i = 1000; i > 0; i--) {
+      Diode.publish()
+    }
+
+    requestAnimationFrame(() => {
+      stub.should.have.been.calledOnce
+      done()
+    })
   })
 
-  it ('can unsubscribed callbacks', function() {
+  it ('can unsubscribed callbacks', function(done) {
     let stub = sinon.stub()
 
     Diode.subscribe(stub);
     Diode.unsubscribe(stub);
     Diode.publish();
 
-    stub.should.not.have.been.called
+    requestAnimationFrame(() => {
+      stub.should.not.have.been.called
+      done()
+    })
   });
 
 });

--- a/tests/diode-test.js
+++ b/tests/diode-test.js
@@ -1,6 +1,16 @@
 describe('Diode', function() {
   var Diode = require('diode')
 
+  it ('does not flush if there are no callbacks', function() {
+    let spy = sinon.spy(window, 'requestAnimationFrame')
+
+    Diode.publish();
+
+    spy.should.not.have.been.called
+
+    spy.restore();
+  })
+
   it ('can subscribe callbacks', function(done) {
     Diode.subscribe(done);
     Diode.publish();


### PR DESCRIPTION
This PR adds lazy, eventual consistency to Diode's callback system (hopefully I didn't botch those buzzwords). Basically it makes this test pass:

``` javascript
it ('batches subscriptions', function(done) {
  let stub = sinon.stub()

  Diode.subscribe(stub);

  for (var i = 1000; i > 0; i--) Diode.publish()

  requestAnimationFrame(function () {
    stub.should.have.been.calledOnce // and only once
    done()
  })
})
```

The neat thing about this is that **all event subscription in React views update at the same time**. We can nearly guarantee batched updates always.
