### PR TITLE
[add] Aliases, new instantiation options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,18 @@
 # Changelog
 
+## 4.3.0
+
+- Added `subscribe` alias for `listen`
+- Added `unsubscribe` alias for `ignore`
+- Added `publish` alias for `emit`
+- Diode can be called with the `new` Operator
+- Diode can decorate objects as a function itself (in addition to decorate)
+
+```
+Compressed : 724 bytes
+Gzipped    : 389 bytes
+```
+
 ## 4.2.0
 
 All Diode methods now return the target. For example, if decorating an existing object:

--- a/README.md
+++ b/README.md
@@ -7,20 +7,13 @@
 
 ---
 
-A simple, eventually consistent, state propagation tool for React. It
-takes advantage of
-[components that are pure](http://facebook.github.io/react/docs/pure-render-mixin.html)
-to significantly simplify event subscription when propagating changes
-in the data layer.
+A simple event emitter with tools for eventual consistency. Diode only
+has one event.
 
 ```javascript
 Diode.listen(callback)
 Diode.emit()
 ```
-
-**Diode is an event emitter with one event**. By including the `Stateful`
-mixin, an expected `getState` method is called every time the Diode
-publishes a change.
 
 **Diode can batch event subscriptions using `volley`**. In
 short, this means that sequential publications will be clumped:
@@ -45,6 +38,10 @@ something similar to it on several projects and decided it was better
 to keep it in one place.
 
 ## Usage
+
+For React projects, Diode includes a `Stateful` mixin, it expects a
+`getState` method that is called every time Diode publishes a
+change.
 
 First include the `Stateful` mixin into a component, and provide a
 `getState` method:
@@ -85,15 +82,38 @@ MyStore.add = function(record) {
 
 And that's it!
 
+## Diode as a decorator
+
+Diode is both an event emitter and a decorator that can add event
+subscription to another object:
+
+```javascript
+var MyData = Diode({
+  data: [],
+  add: function(record) {
+    this.data.push(record)
+    this.publish()
+  }
+})
+```
+
+## New instances of Diode
+
+Diode also supports the `new` operator:
+
+```javascript
+var myDiode = new Diode()
+```
+
 ## API
 
 ### Diode
 
-- `listen`: Remove a callback. If only using the `Stateful` mixin
+- `listen,subscribe`: Remove a callback. If only using the `Stateful` mixin
   this probably never needs to be called
-- `ignore`: Add a callback. If only using the `Stateful` mixin
+- `ignore,unsubscribe`: Add a callback. If only using the `Stateful` mixin
   this probably never needs to be called
-- `emit`: Propagate a change. Call this whenever a data store of
+- `emit,publish`: Propagate a change. Call this whenever a data store of
   some kind changes (leaning on smart `shouldComponentUpdate` methods
   within your React component tree)
 - `volley`: Propagate a change lazily.

--- a/package.json
+++ b/package.json
@@ -1,10 +1,10 @@
 {
   "name": "diode",
   "version": "4.2.0",
-  "description": "A simple, eventually consistent, state propagation tool for Flux/React apps",
+  "description": "A simple event emitter with tools for eventual consistency",
   "main": "src/diode.js",
   "scripts": {
-    "test": "karma start",
+    "test": "karma start --single-run",
     "coveralls": "CONTINUOUS_INTEGRATION=true npm test && coveralls < coverage/report-lcov/lcov.info"
   },
   "repository": {

--- a/src/__tests__/diode-test.js
+++ b/src/__tests__/diode-test.js
@@ -2,6 +2,30 @@ var Diode = require('../diode')
 
 describe('Diode', function() {
 
+  function isDiode(object) {
+    let truth = new Diode()
+
+    for (let key in truth) {
+      object.should.have.property(key)
+    }
+  }
+
+  it ('is an event emitter itself', function() {
+    isDiode(Diode)
+  })
+
+  it ('is a decorator function', function() {
+    let emitter = Diode({ prop: 'yes' })
+
+    isDiode(emitter)
+
+    emitter.should.have.property('prop', 'yes')
+  })
+
+  it ('defaults to an empty object when decorating', function() {
+    isDiode(Diode())
+  })
+
   it ('does not flush if there are no callbacks', function() {
     let spy = sinon.spy(window, 'requestAnimationFrame')
 
@@ -88,6 +112,28 @@ describe('Diode', function() {
       target.ignore(mock).should.equal(target)
       target.emit().should.equal(target)
       target.volley().should.equal(target)
+    })
+  })
+
+  describe('instantiation', function() {
+    it ('can be called with the new operator', function() {
+      let target = new Diode()
+
+      target.should.have.property('listen')
+    })
+  })
+
+  describe('aliases', function() {
+    it ('aliases `listen` to `subscribe` callbacks', function() {
+      Diode.should.have.property('subscribe', Diode.listen)
+    })
+
+    it ('aliases `ignore` to `unsubscribe` callbacks', function() {
+      Diode.should.have.property('unsubscribe', Diode.ignore)
+    })
+
+    it ('aliases `emit` to `publish` callbacks', function() {
+      Diode.should.have.property('publish', Diode.emit)
     })
   })
 })

--- a/src/diode.js
+++ b/src/diode.js
@@ -8,7 +8,11 @@ function Diode(target) {
   var _callbacks = []
   var _tick      = target
 
-  target = target || {}
+  if (this instanceof Diode) {
+    target = this
+  } else {
+    target = target || {}
+  }
 
   /**
    * Callbacks are eventually executed, Diode does not promise
@@ -28,7 +32,7 @@ function Diode(target) {
   /**
    * Given a CALLBACK function, add it to the Set of all callbacks.
    */
-  target.listen = function(callback) {
+  target.listen = target.subscribe = function(callback) {
     _callbacks = _callbacks.concat(callback)
 
     return target
@@ -38,7 +42,7 @@ function Diode(target) {
    * Given a CALLBACK function, remove it from the set of callbacks.
    * Throws an error if the callback is not included in the Set.
    */
-  target.ignore = function(callback) {
+  target.ignore = target.unsubscribe = function(callback) {
     _callbacks = _callbacks.filter(function(i) {
       return i !== callback
     })
@@ -49,7 +53,7 @@ function Diode(target) {
   /**
    * Immediately trigger every callback
    */
-  target.emit = function() {
+  target.emit = target.publish = function() {
     _flush.apply(target, arguments)
 
     return target
@@ -74,5 +78,5 @@ function Diode(target) {
   return target
 }
 
-module.exports = Diode()
+module.exports = Diode(Diode)
 module.exports.decorate = Diode


### PR DESCRIPTION
## 4.3.0
- Added `subscribe` alias for `listen`
- Added `unsubscribe` alias for `ignore`
- Added `publish` alias for `emit`
- Diode can be called with the `new` Operator
- Diode can decorate objects as a function itself (in addition to decorate)
