### PR TITLE
[update] Allow Diode to leak frames every 120FPS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 4.4.0
+
+- When executed continuously, `volley` will now leak out a change
+  event every 120 frames per second. This should better support
+  streaming change events for animation.
+
 ## 4.3.0
 
 - Added `subscribe` alias for `listen`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,9 @@
 
 ## 4.4.0
 
-- When executed continuously, `volley` will now leak out a change
-  event every 120 frames per second. This should better support
-  streaming change events for animation.
+- When executed continuously, at 120 frames per second, `volley` will
+  allow a change event to slip through every frame. This should better
+  support streaming change events for animation.
 
 ```
 Compressed : 592 bytes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@
   event every 120 frames per second. This should better support
   streaming change events for animation.
 
+```
+Compressed : 592 bytes
+Gzipped    : 348 bytes
+```
+
 ## 4.3.0
 
 - Added `subscribe` alias for `listen`

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "main": "src/diode.js",
   "scripts": {
     "test": "karma start --single-run",
+    "test:watch": "karma start",
     "coveralls": "CONTINUOUS_INTEGRATION=true npm test && coveralls < coverage/report-lcov/lcov.info"
   },
   "repository": {

--- a/src/__tests__/diode-test.js
+++ b/src/__tests__/diode-test.js
@@ -46,14 +46,31 @@ describe('Diode', function() {
 
     Diode.listen(stub)
 
-    for (var i = 1000; i > 0; i--) {
+    for (var i = 0; i <= 100; i++) {
+      Diode.volley(i)
+    }
+
+    setTimeout(function() {
+      stub.should.have.been.calledOnce
+      stub.should.have.been.calledWith(100)
+      done()
+    }, 50)
+  })
+
+  it ('allows high-frequency subscriptions to pass through cancellation', function(done) {
+    let stub = sinon.stub()
+    let time = Date.now()
+
+    Diode.listen(stub)
+
+    while (Date.now() - time < Diode.FRAMES * 2) {
       Diode.volley()
     }
 
-    requestAnimationFrame(() => {
-      stub.should.have.been.calledOnce
+    setTimeout(function() {
+      stub.should.have.been.calledTwice
       done()
-    })
+    }, 50)
   })
 
   it ('does not volley if no callbacks exist', function() {
@@ -82,12 +99,8 @@ describe('Diode', function() {
   it ('can decorate other objects', function() {
     let target = Diode.decorate({ prop: 'test' })
 
-    for (var i in Diode) {
-      if (i !== 'decorate') {
-        target.should.have.property(i)
-      }
-    }
-
+    target.should.have.property('publish')
+    target.should.have.property('subscribe')
     target.should.have.property('prop', 'test')
   })
 

--- a/src/diode.js
+++ b/src/diode.js
@@ -4,9 +4,16 @@
  * that state has changed.
  */
 
+/**
+ * Important: 120 FPS is granular enough to get around differences
+ * in the animation and time clock
+ */
+var FRAMES = 1000 / 120
+
 function Diode(target) {
   var _callbacks = []
   var _tick      = target
+  var _lastFire  = null
 
   if (this instanceof Diode) {
     target = this
@@ -18,15 +25,26 @@ function Diode(target) {
    * Callbacks are eventually executed, Diode does not promise
    * immediate consistency so that state propagation can be batched
    */
-  var _flush = function() {
+  var _flush = function(args) {
     /**
      * Important: do not cache the length of _callbacks
      * in the event a callback causes later subscriptions
      * to disappear
      */
     for (var i = 0; i < _callbacks.length; i++) {
-      _callbacks[i].apply(target, arguments)
+      _callbacks[i].apply(target, args)
     }
+  }
+
+  var _cancel = function() {
+    var now = +new Date() // IE8 love
+
+    if (_lastFire && now - _lastFire < 10) {
+      cancelAnimationFrame(_tick)
+    } else {
+      _lastFire = now
+    }
+
   }
 
   /**
@@ -54,8 +72,7 @@ function Diode(target) {
    * Immediately trigger every callback
    */
   target.emit = target.publish = function() {
-    _flush.apply(target, arguments)
-
+    _flush(arguments)
     return target
   }
 
@@ -63,13 +80,9 @@ function Diode(target) {
    * Lazy trigger Trigger every callback
    */
   target.volley = function() {
-    var args = arguments
-
     if (_callbacks.length > 0) {
-      cancelAnimationFrame(_tick)
-      _tick = requestAnimationFrame(function() {
-        _flush.apply(target, args)
-      })
+      _cancel()
+      _tick = requestAnimationFrame(_flush.bind(undefined, arguments))
     }
 
     return target
@@ -78,5 +91,6 @@ function Diode(target) {
   return target
 }
 
-module.exports = Diode(Diode)
+module.exports          = Diode(Diode)
 module.exports.decorate = Diode
+module.exports.FRAMES   = FRAMES


### PR DESCRIPTION
If within an animation loop, it was possible to hit race conditions (I believe this is the right term for it) where requesting another loop before performing work would cause Diode's change event to always cancel. 

This means that this code would properly animate:

``` javascript
requestAnimationFrame(function loop () {
  update() // totally fires, I guess because it gets put onto the stack before the next frame?
  requestAnimationFrame(loop)
})
```

However this would not:

``` javascript
requestAnimationFrame(function loop () {
  requestAnimationFrame(loop)
  update() // magically forgotten
})
```

I still don't fully understand the mechanisms at play. @greypants: any ideas? 

At any rate, this PR makes it so that every 120FPS, a frame will "leak" out. This allows Diode to blast a firehose of change events, batch them together, however make sure that a change event consistently fires at an expected interval.

The result of this is that in Microcosm, you can have an animation loop constantly blast the system with actions and it will properly animate in all cases:

![logo_after](https://cloud.githubusercontent.com/assets/590904/7912785/567b43b4-0838-11e5-82f7-db02742b8f11.gif)

``` javascript
app.listen(function() {
  React.render(<Viget circle={ app.get('circle')}/>, body)
})

requestAnimationFrame(function loop () {
  requestAnimationFrame(loop)
  app.push(updateCircle)
})
```
