### PR TITLE
Add optional scope argument to listen

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,10 +39,39 @@ Diode also supports the `new` operator:
 var myDiode = new Diode()
 ```
 
+## Managing scope
+
+By providing a second argument to `listen`, callbacks will be executed
+within a given context:
+
+```javascript
+var emitter = new Diode()
+
+emitter.listen(function() {
+  assert.equal(this, 'custom context')
+}, 'custom context')
+
+emitter.emit()
+```
+
+
 ## API
 
-### Diode
+### `listen(callback, &scope)`
 
-- `listen,subscribe`: Add a subscription
-- `ignore,unsubscribe`: Remove a subscription
-- `emit,publish`: Trigger all subscriptions
+Add a callback. If a second argument is provided, the callback will be
+executed within that context.
+
+Alias: `subscribe`.
+
+### `ignore(callback)`
+
+Remove a callback.
+
+Alias: `unsubscribe`.
+
+### `emit(...arguments)`
+
+Trigger all subscriptions.
+
+Alias: 'publish'

--- a/src/diode.js
+++ b/src/diode.js
@@ -14,8 +14,8 @@ var Diode = function (app) {
   /**
    * Given a CALLBACK function, add it to the Set of all callbacks.
    */
-  app.listen = app.subscribe = function (callback) {
-    callbacks.push(callback)
+  app.listen = app.subscribe = function (callback, scope) {
+    callbacks.push({ callback: callback, scope: scope || app })
     return app
   }
 
@@ -25,7 +25,7 @@ var Diode = function (app) {
    */
   app.ignore = app.unsubscribe = function (unwanted) {
     callbacks = callbacks.filter(function(entry) {
-      return entry !== unwanted
+      return entry.callback !== unwanted
     })
 
     return app
@@ -36,7 +36,7 @@ var Diode = function (app) {
    */
   app.emit = app.publish = function () {
     for (var i = 0; i < callbacks.length; i++) {
-      callbacks[i].apply(app, arguments)
+      callbacks[i].callback.apply(callbacks[i].scope, arguments)
     }
 
     return app

--- a/test/diode-test.js
+++ b/test/diode-test.js
@@ -84,6 +84,30 @@ describe('Diode', function() {
     })
   })
 
+  describe('scope', function() {
+    it ('if not specified, it calls within the scope of the instance', function(done) {
+      var target = new Diode()
+
+      target.listen(function() {
+        assert.equal(this, target)
+        done()
+      })
+
+      target.emit()
+    })
+
+    it ('listeners can be called within an optional different scope', function(done) {
+      var target = new Diode()
+
+      target.listen(function() {
+        assert.equal(this, 'test')
+        done()
+      }, 'test')
+
+      target.emit()
+    })
+  })
+
   describe('aliases', function() {
     it ('aliases `listen` to `subscribe` callbacks', function() {
       assert.equal(Diode.subscribe, Diode.listen)


### PR DESCRIPTION
When working with Microcosm, and React, I want greater control over the scope of an event listener. In this pull request, I have added an additional argument to `listen` that configures the scope in which it is called.

This should support things in Microcosm such as:

``` javascript
React.createClass({
  componentDidMount() {
    this.props.app.listen(this.setState, this)
  }
})
```
